### PR TITLE
Allow proxy to be used and enhance jndi support

### DIFF
--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnectionFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnectionFactory.java
@@ -17,6 +17,7 @@ import java.io.Serializable;
  * User: Carter Page
  * Date: 3/18/12
  * Time: 8:49 PM
+ * 
  */
 public class NevadoConnectionFactory implements ConnectionFactory, QueueConnectionFactory, TopicConnectionFactory,
         Serializable, Referenceable
@@ -27,6 +28,11 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
     public static final String JNDI_JMS_DELIVERY_MODE = "jmsDeliveryMode";
     public static final String JNDI_JMS_TTL = "jmsTTL";
     public static final String JNDI_JMS_PRIORITY = "jmsPriority";
+    public static final String JNDI_SNS_ENDPOINT = "awsSNSEndpoint";
+	public static final String JNDI_SQS_ENDPOINT = "awsSQSEndpoint";
+	public static final String JNDI_SQS_CONNECTOR_FACTORY_CLASS = "sqsConnectorFactoryClass";
+	public static final String JNDI_PROXY_HOST = "proxyHost";
+	public static final String JNDI_PROXY_PORT = "proxyPort";
 
     private SQSConnectorFactory _sqsConnectorFactory;
     private volatile String _awsAccessKey;
@@ -40,6 +46,8 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
     private String _temporaryQueueSuffix = "";
     private String _temporaryTopicSuffix = "";
     private long _maxPollWaitMs = NevadoConnection.DEFAULT_MAX_POLL_WAIT_MS;
+    private volatile String _proxyHost;
+    private volatile String _proxyPort;
 
     public NevadoConnectionFactory() {}
 
@@ -49,43 +57,72 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
 
     public NevadoQueueConnection createQueueConnection() throws JMSException {
         checkSQSConnectorFactory();
-        NevadoQueueConnection connection = new NevadoQueueConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        NevadoQueueConnection connection;
+        if (_proxyHost != null && _proxyPort != null) {
+        	connection = new NevadoQueueConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint, _proxyHost, _proxyPort));
+        } else {
+        	connection = new NevadoQueueConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        }
         initializeConnection(connection);
         return connection;
     }
 
     public NevadoQueueConnection createQueueConnection(String awsAccessKey, String awsSecretKey) throws JMSException {
         checkSQSConnectorFactory();
-        NevadoQueueConnection connection
-                = new NevadoQueueConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        NevadoQueueConnection connection;
+        if (_proxyHost != null && _proxyPort != null) {
+        	connection = new NevadoQueueConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint, _proxyHost, _proxyPort));
+        } else {
+        	connection = new NevadoQueueConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        }
         initializeConnection(connection);
         return connection;
     }
 
     public NevadoConnection createConnection() throws JMSException {
         checkSQSConnectorFactory();
-        NevadoConnection connection = new NevadoConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        NevadoConnection connection;
+        if (_proxyHost != null && _proxyPort != null) {
+        	connection = new NevadoConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint, _proxyHost, _proxyPort));
+        } else {
+        	connection = new NevadoConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        }
         initializeConnection(connection);
         return connection;
     }
 
     public NevadoConnection createConnection(String awsAccessKey, String awsSecretKey) throws JMSException {
         checkSQSConnectorFactory();
-        NevadoConnection connection = new NevadoConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        NevadoConnection connection;
+        if (_proxyHost != null && _proxyPort != null) {
+        	connection = new NevadoConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint, _proxyHost, _proxyPort));
+        } else {
+        	connection = new NevadoConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        }
         initializeConnection(connection);
         return connection;
     }
 
     public NevadoTopicConnection createTopicConnection() throws JMSException {
         checkSQSConnectorFactory();
-        NevadoTopicConnection connection = new NevadoTopicConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        NevadoTopicConnection connection;
+        if (_proxyHost != null && _proxyPort != null) {
+        	connection = new NevadoTopicConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint, _proxyHost, _proxyPort));
+        } else {
+        	connection = new NevadoTopicConnection(_sqsConnectorFactory.getInstance(_awsAccessKey, _awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        }
         initializeConnection(connection);
         return connection;
     }
 
     public TopicConnection createTopicConnection(String awsAccessKey, String awsSecretKey) throws JMSException {
         checkSQSConnectorFactory();
-        NevadoTopicConnection connection = new NevadoTopicConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        NevadoTopicConnection connection;
+        if (_proxyHost != null && _proxyPort != null) {
+        	connection = new NevadoTopicConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint, _proxyHost, _proxyPort));
+        } else {
+        	connection = new NevadoTopicConnection(_sqsConnectorFactory.getInstance(awsAccessKey, awsSecretKey, _awsSQSEndpoint, _awsSNSEndpoint));
+        }
         initializeConnection(connection);
         return connection;
     }
@@ -140,6 +177,13 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
         _jmsPriority = jmsPriority;
     }
 
+    public void setProxyHost(String proxyHost) {
+		_proxyHost = proxyHost;
+	}
+    
+	public void setProxyPort(String proxyPort) {
+		_proxyPort = proxyPort;
+	}
     public String getAwsAccessKey() {
         return _awsAccessKey;
     }
@@ -163,6 +207,14 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
     public Integer getJMSPriority() {
         return _jmsPriority;
     }
+    
+    public String getProxyHost() {
+		return _proxyHost;
+	}
+
+	public String getProxyPort() {
+		return _proxyPort;
+	}
 
     public void setTemporaryQueueSuffix(String temporaryQueueSuffix) {
         _temporaryQueueSuffix = temporaryQueueSuffix;
@@ -197,6 +249,10 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
         {
             reference.add(new StringRefAddr(JNDI_JMS_PRIORITY, _jmsPriority.toString()));
         }
+        reference.add(new StringRefAddr(JNDI_SNS_ENDPOINT, _awsSNSEndpoint));
+        reference.add(new StringRefAddr(JNDI_SQS_ENDPOINT, _awsSQSEndpoint));
+        reference.add(new StringRefAddr(JNDI_SQS_CONNECTOR_FACTORY_CLASS, null));
+
         return reference;
     }
 
@@ -206,5 +262,6 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
             throw new IllegalStateException("SQSConnectorFactory is null, it must be set.");
         }
     }
+
 }
 

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/AbstractSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/AbstractSQSConnectorFactory.java
@@ -19,6 +19,10 @@ public abstract class AbstractSQSConnectorFactory implements SQSConnectorFactory
 
     @Override
     public abstract SQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint,
+                                             String awsSNSEndpoint, String proxyHost, String proxyPort) throws JMSException;
+    
+    @Override
+    public abstract SQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint,
                                              String awsSNSEndpoint) throws JMSException;
 
     @Override

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/SQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/SQSConnectorFactory.java
@@ -10,4 +10,5 @@ import javax.jms.JMSException;
 public interface SQSConnectorFactory {
     SQSConnector getInstance(String awsAccessKey, String awsSecretKey) throws JMSException;
     SQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint) throws JMSException;
+    SQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint, String proxyPort, String proxyHost) throws JMSException;
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
@@ -1,5 +1,24 @@
 package org.skyscreamer.nevado.jms.connector.amazonaws;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.jms.JMSException;
+import javax.jms.JMSSecurityException;
+import javax.jms.ResourceAllocationException;
+import javax.net.ssl.SSLException;
+
+import org.skyscreamer.nevado.jms.connector.AbstractSQSConnector;
+import org.skyscreamer.nevado.jms.connector.SQSQueue;
+import org.skyscreamer.nevado.jms.destination.NevadoDestination;
+import org.skyscreamer.nevado.jms.destination.NevadoQueue;
+import org.skyscreamer.nevado.jms.destination.NevadoTopic;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
@@ -10,7 +29,14 @@ import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSAsync;
 import com.amazonaws.services.sns.AmazonSNSAsyncClient;
 import com.amazonaws.services.sns.AmazonSNSClient;
-import com.amazonaws.services.sns.model.*;
+import com.amazonaws.services.sns.model.CreateTopicRequest;
+import com.amazonaws.services.sns.model.CreateTopicResult;
+import com.amazonaws.services.sns.model.DeleteTopicRequest;
+import com.amazonaws.services.sns.model.ListTopicsResult;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.SubscribeRequest;
+import com.amazonaws.services.sns.model.Topic;
+import com.amazonaws.services.sns.model.UnsubscribeRequest;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
 import com.amazonaws.services.sqs.AmazonSQSClient;
@@ -18,23 +44,6 @@ import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import com.amazonaws.services.sqs.model.CreateQueueResult;
 import com.amazonaws.services.sqs.model.ListQueuesRequest;
 import com.amazonaws.services.sqs.model.ListQueuesResult;
-import org.skyscreamer.nevado.jms.connector.AbstractSQSConnector;
-import org.skyscreamer.nevado.jms.connector.SQSQueue;
-import org.skyscreamer.nevado.jms.destination.NevadoDestination;
-import org.skyscreamer.nevado.jms.destination.NevadoQueue;
-import org.skyscreamer.nevado.jms.destination.NevadoTopic;
-
-import javax.jms.JMSException;
-import javax.jms.JMSSecurityException;
-import javax.jms.ResourceAllocationException;
-import javax.net.ssl.SSLException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.UnknownHostException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * Connector for SQS-only implementation of the Nevado JMS driver.
@@ -46,13 +55,21 @@ public class AmazonAwsSQSConnector extends AbstractSQSConnector {
     private final AmazonSNS _amazonSNS;
 
     public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs) {
-        this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false);
+        this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false, null, null);
+    }
+    
+    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync) {
+        this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, isAsync, null, null);
     }
 
-    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync) {
+    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync, String proxyHost, String proxyPort) {
         super(receiveCheckIntervalMs, isAsync);
         AWSCredentials awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
         ClientConfiguration clientConfiguration = new ClientConfiguration();
+        if (proxyHost != null && proxyPort != null) {
+        	clientConfiguration.setProxyHost(proxyHost);
+        	clientConfiguration.setProxyPort(Integer.valueOf(proxyPort));
+        }
         clientConfiguration.setProtocol(isSecure ? Protocol.HTTPS : Protocol.HTTP);
         if (isAsync) {
             ExecutorService executorService = Executors.newSingleThreadExecutor();

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
@@ -7,14 +7,15 @@ import org.skyscreamer.nevado.jms.connector.AbstractSQSConnectorFactory;
  * Connectory factory for Amazon AWS connector.
  *
  * @author Carter Page <carter@skyscreamer.org>
+ * 
  */
 public class AmazonAwsSQSConnectorFactory extends AbstractSQSConnectorFactory {
     protected boolean _useAsyncSend = false;
     
     @Override
-    public AmazonAwsSQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint) {
+    public AmazonAwsSQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint, String proxyHost, String proxyPort) {
         AmazonAwsSQSConnector amazonAwsSQSConnector = new AmazonAwsSQSConnector(awsAccessKey, awsSecretKey, _isSecure,
-                _receiveCheckIntervalMs, _useAsyncSend);
+                _receiveCheckIntervalMs, _useAsyncSend, proxyHost, proxyPort);
         if (StringUtils.isNotEmpty(awsSQSEndpoint)) {
             amazonAwsSQSConnector.getAmazonSQS().setEndpoint(awsSQSEndpoint);
         }
@@ -23,6 +24,12 @@ public class AmazonAwsSQSConnectorFactory extends AbstractSQSConnectorFactory {
         }
         return amazonAwsSQSConnector;
     }
+    
+    @Override
+    public AmazonAwsSQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint) {
+        return getInstance(awsAccessKey, awsSecretKey, awsSQSEndpoint, awsSNSEndpoint, null, null);
+    }
+
     
     public void setUseAsyncSend(boolean useAsyncSend) {
         _useAsyncSend = useAsyncSend;

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnectorFactory.java
@@ -26,4 +26,10 @@ public class MockSQSConnectorFactory implements SQSConnectorFactory {
         }
         return _mockSQSConnector;
     }
+    
+    @Override
+    public SQSConnector getInstance(String awsAccessKey, String awsSecretKey, 
+    								String awsSQSEndpoint, String awsSNSEndpoint, String proxyHost, String proxyPort) throws ResourceAllocationException {
+        return getInstance(awsAccessKey, awsSecretKey, null, null);
+    }
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/typica/TypicaSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/typica/TypicaSQSConnectorFactory.java
@@ -17,4 +17,12 @@ public class TypicaSQSConnectorFactory extends AbstractSQSConnectorFactory {
                 awsSNSEndpoint, _isSecure, _receiveCheckIntervalMs);
         return typicaSQSConnector;
     }
+
+    //Added to allow compilation
+	@Override
+	public TypicaSQSConnector getInstance(String awsAccessKey, String awsSecretKey,
+			String awsSQSEndpoint, String awsSNSEndpoint, String proxyHost,
+			String proxyPort) throws JMSException {
+		return getInstance(awsAccessKey, awsSecretKey, awsSQSEndpoint, awsSNSEndpoint);
+	}
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/resource/NevadoReferencableFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/resource/NevadoReferencableFactory.java
@@ -1,6 +1,7 @@
 package org.skyscreamer.nevado.jms.resource;
 
 import org.skyscreamer.nevado.jms.NevadoConnectionFactory;
+import org.skyscreamer.nevado.jms.connector.SQSConnectorFactory;
 import org.skyscreamer.nevado.jms.destination.NevadoDestination;
 import org.skyscreamer.nevado.jms.destination.NevadoQueue;
 import org.skyscreamer.nevado.jms.destination.NevadoTopic;
@@ -16,6 +17,7 @@ import java.util.Hashtable;
  * This is the factory for JNDI referenceable objects.
  *
  * @author Carter Page <carter@skyscreamer.org>
+ * @author Andy Savin <andy.savin@vistair.com>
  */
 public class NevadoReferencableFactory implements ObjectFactory {
     public Object getObjectInstance(Object obj, Name name, Context ctx, Hashtable env) throws Exception
@@ -47,6 +49,31 @@ public class NevadoReferencableFactory implements ObjectFactory {
                 {
                     connectionFactory.setOverrideJMSTTL(Long.parseLong(jmsTtl));
                 }
+                String sqsEndpoint = getRefContent(ref, NevadoConnectionFactory.JNDI_SQS_ENDPOINT);
+                if (sqsEndpoint != null)
+                {
+                    connectionFactory.setAwsSQSEndpoint(sqsEndpoint);
+                }
+                String snsEndPoint = getRefContent(ref, NevadoConnectionFactory.JNDI_SNS_ENDPOINT);
+                if (snsEndPoint != null)
+                {
+                    connectionFactory.setAwsSNSEndpoint(snsEndPoint);
+                }
+                String proxyHost = getRefContent(ref, NevadoConnectionFactory.JNDI_PROXY_HOST);
+                if (proxyHost != null)
+                {
+                    connectionFactory.setProxyHost(proxyHost);
+                }
+                String proxyPort = getRefContent(ref, NevadoConnectionFactory.JNDI_PROXY_PORT);
+                if (proxyPort != null)
+                {
+                    connectionFactory.setProxyPort(proxyPort);
+                }
+                String sqsConnectorFactoryClass = getRefContent(ref, NevadoConnectionFactory.JNDI_SQS_CONNECTOR_FACTORY_CLASS);
+	            if (sqsConnectorFactoryClass != null) {
+	            	SQSConnectorFactory sqsConnectorFactory = (SQSConnectorFactory) Class.forName(sqsConnectorFactoryClass).newInstance();
+	                connectionFactory.setSqsConnectorFactory(sqsConnectorFactory);
+	            }
                 instance = connectionFactory;
             }
             else if (ref.getClassName().equals(NevadoQueue.class.getName())) {


### PR DESCRIPTION
I've added the ability to specify a proxyHost and proxyPort to be used for connection to Amazon (needed when running a private EC2 instance).  I've also improved the JNDI support so you can now specify all the required parameters such as endpoints and the new proxy details.  It would be really great to get this in the next release.  Cheers
Andy
Vistair Systems Ltd
