### PR TITLE
ResettableMock interface integrated with isolated unit tests

### DIFF
--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnector.java
@@ -12,7 +12,7 @@ import java.util.*;
  *
  * @author Carter Page <carter@skyscreamer.org>
  */
-public class MockSQSConnector extends AbstractSQSConnector {
+public class MockSQSConnector extends AbstractSQSConnector implements ResettableMock {
     private final Map<NevadoQueue, MockSQSQueue> _mockQueueMap = new HashMap<NevadoQueue, MockSQSQueue>();
     private final Map<NevadoTopic, Collection<MockSQSQueue>> _mockTopicMap = new HashMap<NevadoTopic, Collection<MockSQSQueue>>();
 
@@ -111,6 +111,14 @@ public class MockSQSConnector extends AbstractSQSConnector {
         }
     }
 
+    @Override
+    public void reset() {
+        Collection<MockSQSQueue> mockSQSQueues = buildSetOfAllMockQueues();
+        for (MockSQSQueue mockSQSQueue : mockSQSQueues) {
+            mockSQSQueue.reset();
+        }
+    }
+
     protected void removeQueue(NevadoQueue queue) {
         _mockQueueMap.remove(queue);
         for(NevadoTopic topic : _mockTopicMap.keySet())
@@ -132,5 +140,18 @@ public class MockSQSConnector extends AbstractSQSConnector {
         {
             throw new JMSException("No such topic: " + topic);
         }
+    }
+
+    private Collection<MockSQSQueue> buildSetOfAllMockQueues(){
+        Collection<MockSQSQueue> mockSQSQueues = new HashSet<MockSQSQueue>();
+
+        mockSQSQueues.addAll(_mockQueueMap.values());
+
+        Collection<Collection<MockSQSQueue>> allTopicQueueCollections = _mockTopicMap.values();
+        for (Collection<MockSQSQueue> topicQueueCollection : allTopicQueueCollections) {
+            mockSQSQueues.addAll(topicQueueCollection);
+        }
+
+        return mockSQSQueues;
     }
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnectorFactory.java
@@ -10,7 +10,7 @@ import javax.jms.ResourceAllocationException;
  *
  * @author Carter Page <carter@skyscreamer.org>
  */
-public class MockSQSConnectorFactory implements SQSConnectorFactory {
+public class MockSQSConnectorFactory implements SQSConnectorFactory, ResettableMock {
     public static final String BAD_ENDPOINT_URL = "http://badurl";
     private MockSQSConnector _mockSQSConnector = new MockSQSConnector();
 
@@ -25,5 +25,10 @@ public class MockSQSConnectorFactory implements SQSConnectorFactory {
             throw new ResourceAllocationException("Bad endpoint");
         }
         return _mockSQSConnector;
+    }
+
+    @Override
+    public void reset() {
+        _mockSQSConnector.reset();
     }
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSQueue.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSQueue.java
@@ -13,7 +13,7 @@ import java.util.LinkedList;
  *
  * @author Carter Page <carter@skyscreamer.org>
  */
-public class MockSQSQueue implements SQSQueue {
+public class MockSQSQueue implements SQSQueue, ResettableMock {
     private static final long DEFAULT_MESSAGE_VISIBILITY = 120000;
     private final LinkedList<MockSQSMessage> _messageList = new LinkedList<MockSQSMessage>();
     private final String _queueARN = RandomData.readString();
@@ -103,6 +103,13 @@ public class MockSQSQueue implements SQSQueue {
             }
         }
         return nextMessage;
+    }
+
+    @Override
+    public synchronized void reset() {
+        if(!_isDeleted){
+            _messageList.clear();
+        }
     }
 
     private void checkIsDeleted() throws JMSException {

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/ResettableMock.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/mock/ResettableMock.java
@@ -1,0 +1,11 @@
+package org.skyscreamer.nevado.jms.connector.mock;
+
+/**
+ * Any bean than implements this interface must provide an implementation which
+ * returns the bean back to a pristine empty state.
+ */
+public interface ResettableMock {
+
+    void reset();
+
+}

--- a/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnectorFactoryTest.java
+++ b/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnectorFactoryTest.java
@@ -1,0 +1,63 @@
+package org.skyscreamer.nevado.jms.connector.mock;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.nevado.jms.NevadoConnection;
+import org.skyscreamer.nevado.jms.destination.NevadoQueue;
+import org.skyscreamer.nevado.jms.message.NevadoMessage;
+import org.skyscreamer.nevado.jms.message.NevadoTextMessage;
+
+public class MockSQSConnectorFactoryTest {
+
+    private static final String ACCESS_KEY = "ACCESS_KEY";
+    private static final String SECRET_KEY = "SECRET_KEY";
+    private static final String QUEUE_NAME = "QUEUE_NAME";
+    private static final String QUEUE_MESSAGE_PAYLOAD = "QUEUE_MESSAGE_PAYLOAD";
+    private static final long DEFAULT_TIMEOUT = 50L;
+
+    private MockSQSConnectorFactory _mockSQSConnectorFactory;
+    private MockSQSConnector _mockSQSConnector;
+    private NevadoQueue _queue;
+    private NevadoTextMessage _queueMessage;
+    private NevadoConnection _nevadoConnection;
+
+
+    @Before
+    public void setUp() throws Exception {
+        _mockSQSConnectorFactory = new MockSQSConnectorFactory();
+        _mockSQSConnector = (MockSQSConnector) _mockSQSConnectorFactory.getInstance(ACCESS_KEY, SECRET_KEY);
+        _nevadoConnection = new NevadoConnection(_mockSQSConnector);
+        _nevadoConnection.start();
+
+        _queue = _mockSQSConnector.createQueue(QUEUE_NAME);
+
+        _queueMessage = new NevadoTextMessage();
+        _queueMessage.setText(QUEUE_MESSAGE_PAYLOAD);
+    }
+
+    @Test
+    public void testFactoryWillSendAndReceiveAMessage() throws Exception {
+        _mockSQSConnector.sendMessage(_queue, _queueMessage);
+
+        NevadoMessage resultMessage = _mockSQSConnector.receiveMessage(_nevadoConnection, _queue, DEFAULT_TIMEOUT);
+
+        Assert.assertNotNull("Message was not returned", resultMessage);
+
+        Assert.assertTrue("Message was not a text message", NevadoTextMessage.class.isAssignableFrom(resultMessage.getClass()));
+
+        Assert.assertEquals("Messages were not equal", _queueMessage.getText() , ((NevadoTextMessage)resultMessage).getText());
+    }
+
+    @Test
+    public void testResetWillResetTheInternalConnectorBackToEmpty() throws Exception {
+        _mockSQSConnector.sendMessage(_queue, _queueMessage);
+
+        _mockSQSConnectorFactory.reset();
+
+        NevadoMessage resultMessage = _mockSQSConnector.receiveMessage(_nevadoConnection, _queue, DEFAULT_TIMEOUT);
+
+        Assert.assertNull("queue message was returned and internal connector should have been reset", resultMessage);
+    }
+
+}

--- a/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnectorTest.java
+++ b/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSConnectorTest.java
@@ -1,0 +1,84 @@
+package org.skyscreamer.nevado.jms.connector.mock;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.nevado.jms.NevadoConnection;
+import org.skyscreamer.nevado.jms.destination.NevadoQueue;
+import org.skyscreamer.nevado.jms.destination.NevadoTopic;
+import org.skyscreamer.nevado.jms.message.NevadoMessage;
+import org.skyscreamer.nevado.jms.message.NevadoTextMessage;
+
+
+public class MockSQSConnectorTest {
+
+    private static final String QUEUE_NAME = "QUEUE_NAME";
+    private static final String TOPIC_NAME = "TOPIC_NAME";
+    private static final String QUEUE_MESSAGE_PAYLOAD = "QUEUE_MESSAGE_PAYLOAD";
+    private static final String TOPIC_MESSAGE_PAYLOAD = "TOPIC_MESSAGE_PAYLOAD";
+    private static final long DEFAULT_TIMEOUT = 50L;
+    private static final String TEMP_QUEUE_NAME = "TEMP_QUEUE_NAME";
+
+    private NevadoConnection _nevadoConnection;
+    private MockSQSConnector _mockSQSConnector;
+
+    private NevadoQueue _queue;
+
+    private NevadoTopic _publishableTopic;
+    private NevadoTopic _subscribableTopic;
+
+    private NevadoTextMessage _queueMessage;
+    private NevadoTextMessage _topicMessage;
+
+    @Before
+    public void setUp() throws Exception {
+        _mockSQSConnector = new MockSQSConnector();
+        _nevadoConnection = new NevadoConnection(_mockSQSConnector);
+        _nevadoConnection.start();
+
+        _queue = _mockSQSConnector.createQueue(QUEUE_NAME);
+
+        _publishableTopic = _mockSQSConnector.createTopic(TOPIC_NAME);
+        NevadoQueue topicEndpoint = _mockSQSConnector.createQueue(TEMP_QUEUE_NAME); // This should be a temp _queue but it is just a mock
+        String subscriptionArn = _mockSQSConnector.subscribe(_publishableTopic, topicEndpoint);
+        _subscribableTopic = new NevadoTopic(_publishableTopic, topicEndpoint, subscriptionArn, false);
+
+        _queueMessage = new NevadoTextMessage();
+        _queueMessage.setText(QUEUE_MESSAGE_PAYLOAD);
+        _topicMessage = new NevadoTextMessage();
+        _topicMessage.setText(TOPIC_MESSAGE_PAYLOAD);
+    }
+
+    @Test
+    public void testMockSQSConnectorWillReturnMessagesWhenNotReset() throws Exception {
+        _mockSQSConnector.sendMessage(_queue, _queueMessage);
+        _mockSQSConnector.sendMessage(_publishableTopic, _topicMessage);
+
+        NevadoMessage resultQueueMessage = _mockSQSConnector.receiveMessage(_nevadoConnection, _queue, DEFAULT_TIMEOUT);
+        NevadoMessage resultTopicMessage = _mockSQSConnector.receiveMessage(_nevadoConnection, _subscribableTopic, DEFAULT_TIMEOUT);
+
+        Assert.assertNotNull("queue message was not returned", resultQueueMessage);
+        Assert.assertNotNull("topic message was not returned", resultTopicMessage);
+
+        Assert.assertTrue("queue message was not a text message", NevadoTextMessage.class.isAssignableFrom(resultQueueMessage.getClass()));
+        Assert.assertTrue("topic message was not a text message", NevadoTextMessage.class.isAssignableFrom(resultTopicMessage.getClass()));
+
+        Assert.assertEquals("queue messages were not equal", _queueMessage.getText() , ((NevadoTextMessage)resultQueueMessage).getText());
+        Assert.assertEquals("topic messages were not equal", _topicMessage.getText(), ((NevadoTextMessage)resultTopicMessage).getText());
+    }
+
+    @Test
+    public void testMockSQSConnectorWillBeEmptyWhenReset() throws Exception {
+        _mockSQSConnector.sendMessage(_queue, _queueMessage);
+        _mockSQSConnector.sendMessage(_publishableTopic, _topicMessage);
+
+        _mockSQSConnector.reset();
+
+        NevadoMessage resultQueueMessage = _mockSQSConnector.receiveMessage(_nevadoConnection, _queue, DEFAULT_TIMEOUT);
+        NevadoMessage resultTopicMessage = _mockSQSConnector.receiveMessage(_nevadoConnection, _subscribableTopic, DEFAULT_TIMEOUT);
+
+        Assert.assertNull("queue message was returned and connector should have been reset", resultQueueMessage);
+        Assert.assertNull("topic message was returned and connector should have been reset", resultTopicMessage);
+    }
+
+}

--- a/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSQueueTest.java
+++ b/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/connector/mock/MockSQSQueueTest.java
@@ -1,0 +1,51 @@
+package org.skyscreamer.nevado.jms.connector.mock;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.nevado.jms.connector.SQSMessage;
+import org.skyscreamer.nevado.jms.destination.NevadoQueue;
+
+public class MockSQSQueueTest {
+
+    private static final String QUEUE_NAME = "QUEUE_NAME";
+    private static final String MESSAGE_BODY = "MESSAGE_BODY";
+
+    private MockSQSQueue _mockSQSQueue;
+
+    private MockSQSConnector _connector;
+
+    private NevadoQueue _queue;
+
+    @Before
+    public void setup(){
+        _queue = new NevadoQueue(QUEUE_NAME);
+        _connector = new MockSQSConnector();
+        _mockSQSQueue = new MockSQSQueue(_connector, _queue);
+    }
+
+    @Test
+    public void testQueueWorksAsExpectedForNonResetQueue() throws Exception {
+        _mockSQSQueue.sendMessage(MESSAGE_BODY);
+        SQSMessage sqsMessage = _mockSQSQueue.receiveMessage();
+        Assert.assertNotNull("Message was not returned from internal list", sqsMessage);
+        Assert.assertEquals("Message bodies were not equal", MESSAGE_BODY, sqsMessage.getMessageBody());
+        sqsMessage = _mockSQSQueue.receiveMessage();
+        Assert.assertNull("Message was returned but internal list should have been empty", sqsMessage);
+    }
+
+    @Test
+    public void testQueueCanBeReset() throws Exception {
+        _mockSQSQueue.sendMessage(MESSAGE_BODY);
+        _mockSQSQueue.reset();
+        SQSMessage sqsMessage = _mockSQSQueue.receiveMessage();
+        Assert.assertNull("Message was returned but internal list should have been empty", sqsMessage);
+    }
+
+    @Test
+    public void testQueueResetDoesNotThrowExceptionIfQueueIsDeleted() throws Exception {
+        _mockSQSQueue.sendMessage(MESSAGE_BODY);
+        _mockSQSQueue.deleteQueue();
+        _mockSQSQueue.reset();
+    }
+}

--- a/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/facilities/ConnectionFactoryResetTest.java
+++ b/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/facilities/ConnectionFactoryResetTest.java
@@ -1,0 +1,44 @@
+package org.skyscreamer.nevado.jms.facilities;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.skyscreamer.nevado.jms.AbstractJMSTest;
+import org.skyscreamer.nevado.jms.NevadoConnectionFactory;
+import org.skyscreamer.nevado.jms.connector.mock.ResettableMock;
+import org.skyscreamer.nevado.jms.util.RandomData;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.jms.*;
+import java.util.Collection;
+
+public class ConnectionFactoryResetTest extends AbstractJMSTest{
+
+    private static final String QUEUE_NAME = "QUEUE_NAME";
+
+    @Autowired
+    private Collection<ResettableMock> _resettableMocks;
+
+    @Test
+    public void testResetWillEmptyQueue() throws Exception {
+
+        NevadoConnectionFactory connectionFactory = new NevadoConnectionFactory(_sqsConnectorFactory);
+        Connection connection = createConnection(connectionFactory);
+        connection.start();
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+        Queue queue = session.createQueue(QUEUE_NAME);
+        MessageProducer producer = session.createProducer(queue);
+        MessageConsumer consumer = session.createConsumer(queue);
+        TextMessage testMessage = session.createTextMessage(RandomData.readString());
+        producer.send(testMessage);
+
+        for (ResettableMock resettableMock : _resettableMocks) {
+            resettableMock.reset();
+        }
+
+        Message msgOut = consumer.receive(2000);
+        Assert.assertNull(msgOut);
+        connection.close();
+
+    }
+}


### PR DESCRIPTION
The impacted mock classes and their new reset method have a combination of isolation and integration unit testing. Integration unit test is quite focused and simple to ensure that the interface resolves by the Autowired annotation and the reset clears the mocks of the sent message. It confirms this and also confirms simple usage with the spring context wired together. Change relates to issue 64. https://github.com/skyscreamer/nevado/issues/64
