### PR TITLE
JNDI additions and ability to override the durable subscription prefix

### DIFF
--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnection.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnection.java
@@ -39,6 +39,7 @@ public class NevadoConnection implements Connection {
     private String _temporaryQueueSuffix = "";
     private String _temporaryTopicSuffix = "";
     private long _maxPollWaitMs = DEFAULT_MAX_POLL_WAIT_MS;
+    private String _durableSubcriptionPrefixOveride;
 
     public NevadoConnection(SQSConnector sqsConnector) throws JMSException {
         _sqsConnector = sqsConnector;
@@ -363,5 +364,13 @@ public class NevadoConnection implements Connection {
 
     public String getConnectionID() {
         return _connectionID;
+    }
+    
+    public void setDurableSubcriptionPrefixOveride(String durableSubcriptionPrefixOveride) {
+        _durableSubcriptionPrefixOveride = durableSubcriptionPrefixOveride;
+    }
+    
+    public String getDurableSubcriptionPrefixOveride() {
+        return _durableSubcriptionPrefixOveride;
     }
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnectionFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnectionFactory.java
@@ -45,7 +45,7 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
     private String _temporaryQueueSuffix = "";
     private String _temporaryTopicSuffix = "";
     private long _maxPollWaitMs = NevadoConnection.DEFAULT_MAX_POLL_WAIT_MS;
-    private String _durableSubscriberPrefixOverride = null;
+    private volatile String _durableSubscriberPrefixOverride = null;
 
     public NevadoConnectionFactory() {}
 
@@ -113,6 +113,10 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
     // Getters & Setters
     public void setSqsConnectorFactory(SQSConnectorFactory sqsConnectorFactory) {
         _sqsConnectorFactory = sqsConnectorFactory;
+    }
+    
+    public SQSConnectorFactory getSqsConnectorFactory() {
+        return _sqsConnectorFactory;
     }
 
     public void setAwsAccessKey(String awsAccessKey) {
@@ -186,6 +190,23 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
     public void setDurableSubscriberPrefixOverride(String durableSubscriberPrefixOverride) {
         _durableSubscriberPrefixOverride = durableSubscriberPrefixOverride;
     }
+    
+    public String getAwsSQSEndpoint() {
+       return _awsSQSEndpoint;
+    }
+
+    public String getAwsSNSEndpoint() {
+        return _awsSNSEndpoint;
+    }
+    
+    public long getMaxPollWaitMs() {
+         return _maxPollWaitMs;
+    }
+    
+    public String getDurableSubscriberPrefixOverride() {
+        return _durableSubscriberPrefixOverride;
+    }
+
 
     public Reference getReference() throws NamingException {
         Reference reference = new Reference(NevadoConnectionFactory.class.getName(),
@@ -208,6 +229,24 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
         {
             reference.add(new StringRefAddr(JNDI_JMS_PRIORITY, _jmsPriority.toString()));
         }
+        if (_awsSNSEndpoint != null)
+        {
+            reference.add(new StringRefAddr(JNDI_SNS_ENDPOINT, _awsSNSEndpoint.toString()));
+        }
+        if (_awsSQSEndpoint != null)
+        {
+            reference.add(new StringRefAddr(JNDI_SQS_ENDPOINT, _awsSQSEndpoint.toString()));
+        }
+        reference.add(new StringRefAddr(JNDI_MAX_POLL_WAIT_MS, String.valueOf(_maxPollWaitMs)));
+        if (_durableSubscriberPrefixOverride != null)
+        {
+            reference.add(new StringRefAddr(JNDI_DURABLE_SUBSCRIBER_PREFIX_OVERRIDE, _durableSubscriberPrefixOverride.toString()));
+        }
+        String sqsConnectorFactoryClass = null;
+        if (_sqsConnectorFactory != null) {
+            sqsConnectorFactoryClass = _sqsConnectorFactory.getClass().getName();
+        }
+        reference.add(new StringRefAddr(JNDI_SQS_CONNECTOR_FACTORY_CLASS, sqsConnectorFactoryClass));
         return reference;
     }
 

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnectionFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnectionFactory.java
@@ -27,6 +27,11 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
     public static final String JNDI_JMS_DELIVERY_MODE = "jmsDeliveryMode";
     public static final String JNDI_JMS_TTL = "jmsTTL";
     public static final String JNDI_JMS_PRIORITY = "jmsPriority";
+    public static final String JNDI_SNS_ENDPOINT = "awsSNSEndpoint";
+    public static final String JNDI_SQS_ENDPOINT = "awsSQSEndpoint";
+    public static final String JNDI_SQS_CONNECTOR_FACTORY_CLASS = "sqsConnectorFactoryClass";
+    public static final String JNDI_MAX_POLL_WAIT_MS = "maxPollWaitMs";
+    public static final String JNDI_DURABLE_SUBSCRIBER_PREFIX_OVERRIDE = "durableSubscriberPrefixOverride";
 
     private SQSConnectorFactory _sqsConnectorFactory;
     private volatile String _awsAccessKey;
@@ -40,6 +45,7 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
     private String _temporaryQueueSuffix = "";
     private String _temporaryTopicSuffix = "";
     private long _maxPollWaitMs = NevadoConnection.DEFAULT_MAX_POLL_WAIT_MS;
+    private String _durableSubscriberPrefixOverride = null;
 
     public NevadoConnectionFactory() {}
 
@@ -101,6 +107,7 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
         connection.setTemporaryQueueSuffix(_temporaryQueueSuffix);
         connection.setTemporaryTopicSuffix(_temporaryTopicSuffix);
         connection.setMaxPollWaitMs(_maxPollWaitMs);
+        connection.setDurableSubcriptionPrefixOveride(_durableSubscriberPrefixOverride);
     }
 
     // Getters & Setters
@@ -174,6 +181,10 @@ public class NevadoConnectionFactory implements ConnectionFactory, QueueConnecti
 
     public void setMaxPollWaitMs(long maxPollWaitMs) {
         _maxPollWaitMs = maxPollWaitMs;
+    }
+    
+    public void setDurableSubscriberPrefixOverride(String durableSubscriberPrefixOverride) {
+        _durableSubscriberPrefixOverride = durableSubscriberPrefixOverride;
     }
 
     public Reference getReference() throws NamingException {

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoSession.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoSession.java
@@ -344,6 +344,10 @@ public class NevadoSession implements Session {
 
     protected String getDurableEndpointQueueName(String durableSubscriptionName) {
         String queueName = NevadoProviderQueuePrefix.DURABLE_SUBSCRIPTION_PREFIX + durableSubscriptionName;
+        if (_connection.getDurableSubcriptionPrefixOveride() != null) 
+        {
+            queueName = _connection.getDurableSubcriptionPrefixOveride() + durableSubscriptionName;
+        }
         if (_connection.getClientID() != null)
         {
             queueName += "_client-" + _connection.getClientID() + "";

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoSession.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoSession.java
@@ -343,11 +343,16 @@ public class NevadoSession implements Session {
     }
 
     protected String getDurableEndpointQueueName(String durableSubscriptionName) {
-        String queueName = NevadoProviderQueuePrefix.DURABLE_SUBSCRIPTION_PREFIX + durableSubscriptionName;
+        String queueName;
         if (_connection.getDurableSubcriptionPrefixOveride() != null) 
         {
             queueName = _connection.getDurableSubcriptionPrefixOveride() + durableSubscriptionName;
+        } 
+        else 
+        {
+            queueName = NevadoProviderQueuePrefix.DURABLE_SUBSCRIPTION_PREFIX + durableSubscriptionName;
         }
+        
         if (_connection.getClientID() != null)
         {
             queueName += "_client-" + _connection.getClientID() + "";

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/resource/NevadoReferencableFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/resource/NevadoReferencableFactory.java
@@ -1,16 +1,18 @@
 package org.skyscreamer.nevado.jms.resource;
 
-import org.skyscreamer.nevado.jms.NevadoConnectionFactory;
-import org.skyscreamer.nevado.jms.destination.NevadoDestination;
-import org.skyscreamer.nevado.jms.destination.NevadoQueue;
-import org.skyscreamer.nevado.jms.destination.NevadoTopic;
+import java.util.Hashtable;
 
 import javax.naming.Context;
 import javax.naming.Name;
 import javax.naming.RefAddr;
 import javax.naming.Reference;
 import javax.naming.spi.ObjectFactory;
-import java.util.Hashtable;
+
+import org.skyscreamer.nevado.jms.NevadoConnectionFactory;
+import org.skyscreamer.nevado.jms.connector.SQSConnectorFactory;
+import org.skyscreamer.nevado.jms.destination.NevadoDestination;
+import org.skyscreamer.nevado.jms.destination.NevadoQueue;
+import org.skyscreamer.nevado.jms.destination.NevadoTopic;
 
 /**
  * This is the factory for JNDI referenceable objects.
@@ -46,6 +48,32 @@ public class NevadoReferencableFactory implements ObjectFactory {
                 if (jmsTtl != null)
                 {
                     connectionFactory.setOverrideJMSTTL(Long.parseLong(jmsTtl));
+                }
+                String sqsEndpoint = getRefContent(ref, NevadoConnectionFactory.JNDI_SQS_ENDPOINT);
+                if (sqsEndpoint != null)
+                {
+                    connectionFactory.setAwsSQSEndpoint(sqsEndpoint);
+                }
+                String snsEndPoint = getRefContent(ref, NevadoConnectionFactory.JNDI_SNS_ENDPOINT);
+                if (snsEndPoint != null)
+                {
+                    connectionFactory.setAwsSNSEndpoint(snsEndPoint);
+                }
+                String maxPollWaitMs = getRefContent(ref, NevadoConnectionFactory.JNDI_MAX_POLL_WAIT_MS);
+                if (maxPollWaitMs != null)
+                {
+                    connectionFactory.setMaxPollWaitMs(Long.valueOf(maxPollWaitMs));
+                }
+                String durableSubscriberPrefixOverride = getRefContent(ref, NevadoConnectionFactory.JNDI_DURABLE_SUBSCRIBER_PREFIX_OVERRIDE);
+                if (durableSubscriberPrefixOverride != null)
+                {
+                    connectionFactory.setDurableSubscriberPrefixOverride(durableSubscriberPrefixOverride);
+                }
+                String sqsConnectorFactoryClass = getRefContent(ref, NevadoConnectionFactory.JNDI_SQS_CONNECTOR_FACTORY_CLASS);
+                if (sqsConnectorFactoryClass != null) 
+                {
+                    SQSConnectorFactory sqsConnectorFactory = (SQSConnectorFactory) Class.forName(sqsConnectorFactoryClass).newInstance();
+                    connectionFactory.setSqsConnectorFactory(sqsConnectorFactory);
                 }
                 instance = connectionFactory;
             }

--- a/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/resource/ReferencableTest.java
+++ b/nevado-jms/src/test/java/org/skyscreamer/nevado/jms/resource/ReferencableTest.java
@@ -30,7 +30,10 @@ public class ReferencableTest extends AbstractJMSTest {
     private static final Integer TEST_DELIVERY_MODE = (int)RandomData.readShort();
     private static final Integer TEST_PRIORITY = (new Random()).nextInt(10);
     private static final Long TEST_TTL = (long)RandomData.readInt();
-
+    private static final String TEST_SQS_ENDPOINT = RandomData.readString();
+    private static final String TEST_SNS_ENDPOINT = RandomData.readString();
+    private static final Long TEST_MAX_POLL_WAIT = (long) RandomData.readInt();
+    private static final String TEST_DURABLE_SUBSCRIBER_PREFIX = RandomData.readString();
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -43,6 +46,10 @@ public class ReferencableTest extends AbstractJMSTest {
         connectionFactory.setOverrideJMSDeliveryMode(TEST_DELIVERY_MODE);
         connectionFactory.setOverrideJMSPriority(TEST_PRIORITY);
         connectionFactory.setOverrideJMSTTL(TEST_TTL);
+        connectionFactory.setAwsSQSEndpoint(TEST_SQS_ENDPOINT);
+        connectionFactory.setAwsSNSEndpoint(TEST_SNS_ENDPOINT);
+        connectionFactory.setDurableSubscriberPrefixOverride(TEST_DURABLE_SUBSCRIBER_PREFIX);
+        connectionFactory.setMaxPollWaitMs(TEST_MAX_POLL_WAIT);
         Context ctx = getContext();
         ctx.bind("testConnectionFactory", connectionFactory);
         NevadoConnectionFactory testConnectionFactory = (NevadoConnectionFactory)ctx.lookup("testConnectionFactory");
@@ -52,6 +59,11 @@ public class ReferencableTest extends AbstractJMSTest {
         Assert.assertEquals(connectionFactory.getJMSDeliveryMode(), testConnectionFactory.getJMSDeliveryMode());
         Assert.assertEquals(connectionFactory.getJMSPriority(), testConnectionFactory.getJMSPriority());
         Assert.assertEquals(connectionFactory.getJMSTTL(), testConnectionFactory.getJMSTTL());
+        Assert.assertEquals(connectionFactory.getAwsSQSEndpoint(), testConnectionFactory.getAwsSQSEndpoint());
+        Assert.assertEquals(connectionFactory.getAwsSNSEndpoint(), testConnectionFactory.getAwsSNSEndpoint());
+        Assert.assertEquals(connectionFactory.getDurableSubscriberPrefixOverride(), testConnectionFactory.getDurableSubscriberPrefixOverride());
+        Assert.assertEquals(connectionFactory.getMaxPollWaitMs(), testConnectionFactory.getMaxPollWaitMs());
+        Assert.assertEquals(connectionFactory.getSqsConnectorFactory().getClass().getName(), testConnectionFactory.getSqsConnectorFactory().getClass().getName());
         ctx.close();
     }
 


### PR DESCRIPTION
I've re-forked and started again.  Changes are as follows:

Updated JNDI factory to allow specification of SNS and SQS endpoints, the SQSConnectorFactory class name, the max poll wait time and an override for the durable subscription prefix.

I've also updated the NevadoSession to use this prefix instead of the default if it is set.  Amazon seems to have an 80 character limit on the name of a subscriber and nevado_durable_topic took up a bit too much of that allocation for our needs.

I don't think I've changed anything that would require a unit test however, let me know and I'll try and create some.

Andy
