### PR TITLE
Proposed fixes for issue 81

### DIFF
--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/AbstractSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/AbstractSQSConnector.java
@@ -273,6 +273,7 @@ public abstract class AbstractSQSConnector implements SQSConnector {
     protected String serializeMessage(NevadoMessage message) throws JMSException {
         String serializedMessage;
         try {
+            // TODO: should this use the OOS version @ // for https://github.com/skyscreamer/nevado/issues/81
             serializedMessage = SerializeUtil.serializeToString(message);
         } catch (IOException e) {
             String exMessage = "Unable to serialize message of type " + message.getClass().getName() + ": " + e.getMessage();
@@ -292,6 +293,7 @@ public abstract class AbstractSQSConnector implements SQSConnector {
     protected NevadoMessage deserializeMessage(String serializedMessage) throws JMSException {
         Serializable deserializedObject;
         try {
+            // TODO: should this use the OOS version @ // for https://github.com/skyscreamer/nevado/issues/81
             deserializedObject = SerializeUtil.deserializeFromString(serializedMessage);
         } catch (IOException e) {
             String exMessage = "Unable to deserialized message: " + e.getMessage();

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/message/NevadoObjectMessage.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/message/NevadoObjectMessage.java
@@ -45,7 +45,8 @@ public class NevadoObjectMessage extends NevadoMessage implements ObjectMessage 
         }
         else {
             try {
-                _bodyBytes = SerializeUtil.serialize(serializable);
+                // for https://github.com/skyscreamer/nevado/issues/81
+                _bodyBytes = SerializeUtil.serializeOOS(serializable,false);
             } catch (IOException e) {
                 throw new JMSException("Unable to serialize body object");
             }
@@ -58,7 +59,8 @@ public class NevadoObjectMessage extends NevadoMessage implements ObjectMessage 
         }
         else {
             try {
-                return SerializeUtil.deserialize(_bodyBytes);
+                // for https://github.com/skyscreamer/nevado/issues/81
+                return SerializeUtil.deserializeOOS(_bodyBytes,false);
             } catch (IOException e) {
                 throw new JMSException("Unable to deserialize body object");
             }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/ClassLoading.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/ClassLoading.java
@@ -1,0 +1,244 @@
+/**
+    *
+    * Copyright 2004 The Apache Software Foundation
+    *
+    *  Licensed under the Apache License, Version 2.0 (the "License");
+    *  you may not use this file except in compliance with the License.
+    *  You may obtain a copy of the License at
+    *
+    *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   *  Unless required by applicable law or agreed to in writing, software
+   *  distributed under the License is distributed on an "AS IS" BASIS,
+   *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   *  See the License for the specific language governing permissions and
+   *  limitations under the License.
+   *
+   * COPIED From the Apache ActiveMQ project to address
+   * https://github.com/skyscreamer/nevado/issues/81
+   */
+   
+  
+  package org.skyscreamer.nevado.jms.util;
+  
+  import java.lang.reflect.Array;
+  import java.util.HashMap;
+  import java.util.Map;
+  
+  /**
+   * Utilities for loading classes.
+   * 
+   * @version $Rev: 109957 $ $Date: 2005/03/11 21:14:53 $
+   */
+  public class ClassLoading {
+  
+      /**
+       * Load a class for the given name. <p/>
+       * <p>
+       * Handles loading primitive types as well as VM class and array syntax.
+       * 
+       * @param className
+       *            The name of the Class to be loaded.
+       * @param classLoader
+       *            The class loader to load the Class object from.
+       * @return The Class object for the given name.
+       * @throws ClassNotFoundException
+       *             Failed to load Class object.
+       */
+      public static Class loadClass(final String className, final ClassLoader classLoader) throws ClassNotFoundException {
+          if (className == null) {
+              throw new IllegalArgumentException("className is null");
+          }
+  
+          // First just try to load
+          try {
+              return load(className, classLoader);
+          } catch (ClassNotFoundException ignore) {
+              // handle special cases below
+          }
+  
+          Class type = null;
+  
+          // Check if it is a primitive type
+          type = getPrimitiveType(className);
+          if (type != null)
+              return type;
+  
+          // Check if it is a vm primitive
+          type = getVMPrimitiveType(className);
+          if (type != null)
+              return type;
+  
+          // Handle VM class syntax (Lclassname;)
+          if (className.charAt(0) == 'L' && className.charAt(className.length() - 1) == ';') {
+              String name = className.substring(1, className.length() - 1);
+              return load(name, classLoader);
+          }
+  
+          // Handle VM array syntax ([type)
+          if (className.charAt(0) == '[') {
+              int arrayDimension = className.lastIndexOf('[') + 1;
+              String componentClassName = className.substring(arrayDimension, className.length());
+              type = loadClass(componentClassName, classLoader);
+  
+              int dim[] = new int[arrayDimension];
+              java.util.Arrays.fill(dim, 0);
+              return Array.newInstance(type, dim).getClass();
+          }
+  
+          // Handle user friendly type[] syntax
+          if (className.endsWith("[]")) {
+              // get the base component class name and the arrayDimensions
+              int arrayDimension = 0;
+              String componentClassName = className;
+              while (componentClassName.endsWith("[]")) {
+                  componentClassName = componentClassName.substring(0, componentClassName.length() - 2);
+                  arrayDimension++;
+              }
+  
+              // load the base type
+              type = loadClass(componentClassName, classLoader);
+  
+              // return the array type
+              int[] dim = new int[arrayDimension];
+              java.util.Arrays.fill(dim, 0);
+             return Array.newInstance(type, dim).getClass();
+         }
+ 
+         // Else we can not load (give up)
+         throw new ClassNotFoundException(className);
+     }
+ 
+     private static Class load(final String className, final ClassLoader classLoader) throws ClassNotFoundException {
+         if (classLoader == null)
+             return Class.forName(className);
+         else
+             return classLoader.loadClass(className);
+     }
+ 
+     public static String getClassName(Class clazz) {
+         StringBuffer rc = new StringBuffer();
+         while (clazz.isArray()) {
+             rc.append('[');
+             clazz = clazz.getComponentType();
+         }
+         if (!clazz.isPrimitive()) {
+             rc.append('L');
+             rc.append(clazz.getName());
+             rc.append(';');
+         } else {
+             rc.append(VM_PRIMITIVES_REVERSE.get(clazz));
+         }
+         return rc.toString();
+     }
+ 
+     /**
+      * Primitive type name -> class map.
+      */
+     private static final Map PRIMITIVES = new HashMap();
+ 
+     /** Setup the primitives map. */
+     static {
+         PRIMITIVES.put("boolean", Boolean.TYPE);
+         PRIMITIVES.put("byte", Byte.TYPE);
+         PRIMITIVES.put("char", Character.TYPE);
+         PRIMITIVES.put("short", Short.TYPE);
+         PRIMITIVES.put("int", Integer.TYPE);
+         PRIMITIVES.put("long", Long.TYPE);
+         PRIMITIVES.put("float", Float.TYPE);
+         PRIMITIVES.put("double", Double.TYPE);
+         PRIMITIVES.put("void", Void.TYPE);
+     }
+ 
+     /**
+      * Get the primitive type for the given primitive name.
+      * 
+      * @param name
+      *            Primitive type name (boolean, byte, int, ...)
+      * @return Primitive type or null.
+      */
+     private static Class getPrimitiveType(final String name) {
+         return (Class) PRIMITIVES.get(name);
+     }
+ 
+     /**
+      * VM primitive type name -> primitive type
+      */
+     private static final HashMap VM_PRIMITIVES = new HashMap();
+ 
+     /** Setup the vm primitives map. */
+     static {
+         VM_PRIMITIVES.put("B", byte.class);
+         VM_PRIMITIVES.put("C", char.class);
+         VM_PRIMITIVES.put("D", double.class);
+         VM_PRIMITIVES.put("F", float.class);
+         VM_PRIMITIVES.put("I", int.class);
+         VM_PRIMITIVES.put("J", long.class);
+         VM_PRIMITIVES.put("S", short.class);
+         VM_PRIMITIVES.put("Z", boolean.class);
+         VM_PRIMITIVES.put("V", void.class);
+     }
+ 
+     /**
+      * VM primitive type primitive type -> name
+      */
+     private static final HashMap VM_PRIMITIVES_REVERSE = new HashMap();
+ 
+     /** Setup the vm primitives reverse map. */
+     static {
+         VM_PRIMITIVES_REVERSE.put(byte.class, "B");
+         VM_PRIMITIVES_REVERSE.put(char.class, "C");
+         VM_PRIMITIVES_REVERSE.put(double.class, "D");
+         VM_PRIMITIVES_REVERSE.put(float.class, "F");
+         VM_PRIMITIVES_REVERSE.put(int.class, "I");
+         VM_PRIMITIVES_REVERSE.put(long.class, "J");
+         VM_PRIMITIVES_REVERSE.put(short.class, "S");
+         VM_PRIMITIVES_REVERSE.put(boolean.class, "Z");
+         VM_PRIMITIVES_REVERSE.put(void.class, "V");
+     }
+ 
+     /**
+      * Get the primitive type for the given VM primitive name. <p/>
+      * <p>
+      * Mapping:
+      * 
+      * <pre>
+      * 
+      *    B - byte
+      *    C - char
+      *    D - double
+      *    F - float
+      *    I - int
+      *    J - long
+      *    S - short
+      *    Z - boolean
+      *    V - void
+      *  
+      * </pre>
+      * 
+      * @param name
+      *            VM primitive type name (B, C, J, ...)
+      * @return Primitive type or null.
+      */
+     private static Class getVMPrimitiveType(final String name) {
+         return (Class) VM_PRIMITIVES.get(name);
+     }
+ 
+     /**
+      * Map of primitive types to their wrapper classes
+      */
+     private static final Map PRIMITIVE_WRAPPERS = new HashMap();
+ 
+     /** Setup the wrapper map. */
+     static {
+         PRIMITIVE_WRAPPERS.put(Boolean.TYPE, Boolean.class);
+         PRIMITIVE_WRAPPERS.put(Byte.TYPE, Byte.class);
+         PRIMITIVE_WRAPPERS.put(Character.TYPE, Character.class);
+         PRIMITIVE_WRAPPERS.put(Double.TYPE, Double.class);
+         PRIMITIVE_WRAPPERS.put(Float.TYPE, Float.class);
+         PRIMITIVE_WRAPPERS.put(Integer.TYPE, Integer.class);
+         PRIMITIVE_WRAPPERS.put(Long.TYPE, Long.class);
+         PRIMITIVE_WRAPPERS.put(Short.TYPE, Short.class);
+         PRIMITIVE_WRAPPERS.put(Void.TYPE, Void.class);
+     }
+ }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/ClassLoadingAwareObjectInputStream.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/ClassLoadingAwareObjectInputStream.java
@@ -1,0 +1,49 @@
+package org.skyscreamer.nevado.jms.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.lang.reflect.Proxy;
+
+/**
+ * Copied from ActiveMQ project for addressing http://github.com/skyscreamer/nevado/issues/81
+ 
+ * @author http://activemq.apache.org/maven/5.9.0/apidocs/org/apache/activemq/util/ClassLoadingAwareObjectInputStream.html
+ *
+ */
+public class ClassLoadingAwareObjectInputStream extends ObjectInputStream {
+	
+    private static final ClassLoader FALLBACK_CLASS_LOADER = ClassLoadingAwareObjectInputStream.class.getClassLoader();
+
+    public ClassLoadingAwareObjectInputStream(InputStream in) throws IOException {
+        super(in);
+    }
+
+    protected Class resolveClass(ObjectStreamClass classDesc) throws IOException, ClassNotFoundException {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        return load(classDesc.getName(), cl);
+    }
+
+    protected Class resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        Class[] cinterfaces = new Class[interfaces.length];
+        for (int i = 0; i < interfaces.length; i++)
+            cinterfaces[i] = load(interfaces[i], cl);
+
+        try {
+            return Proxy.getProxyClass(cinterfaces[0].getClassLoader(), cinterfaces);
+        } catch (IllegalArgumentException e) {
+            throw new ClassNotFoundException(null, e);
+        }
+    }
+
+    private Class load(String className, ClassLoader cl) throws ClassNotFoundException {
+        try {
+            return ClassLoading.loadClass(className, cl);
+        } catch ( ClassNotFoundException e ) {
+            return ClassLoading.loadClass(className, FALLBACK_CLASS_LOADER);
+        }
+    }
+
+}

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/SerializeUtil.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/SerializeUtil.java
@@ -19,6 +19,12 @@ import java.util.zip.InflaterInputStream;
 
 public class SerializeUtil
 {
+	
+    public static Serializable copyOOS( Serializable serializable ) throws IOException
+    {
+        return deserializeOOS(serializeOOS(serializable));
+    }
+    
     public static Serializable copy( Serializable serializable ) throws IOException
     {
         return deserialize(serialize(serializable));
@@ -27,6 +33,12 @@ public class SerializeUtil
     public static String serializeToString( Serializable serializable ) throws IOException
     {
         byte[] data = serialize(serializable);
+        return new String( Base64.encodeBase64(data) );
+    }
+    
+    public static String serializeToStringOOS( Serializable serializable ) throws IOException
+    {
+        byte[] data = serializeOOS(serializable);
         return new String( Base64.encodeBase64(data) );
     }
 
@@ -48,6 +60,9 @@ public class SerializeUtil
         return byteArrayOutputStream.toByteArray();
     }
     
+    /**
+     *  @see https://github.com/skyscreamer/nevado/issues/81
+     */
     public static byte[] serializeOOS(Serializable serializable, boolean compress) throws IOException {
   
 	ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
@@ -74,6 +89,7 @@ public class SerializeUtil
         return deserialize(dataBytes);
     }
     
+    
     public static Serializable deserializeFromStringOOS(String s) throws IOException
     {
         // Initialize buffer and converter
@@ -98,6 +114,9 @@ public class SerializeUtil
         return serializable;
     }
     
+    /**
+     *  @see https://github.com/skyscreamer/nevado/issues/81
+     */
     public static Serializable deserializeOOS(byte[] dataBytes, boolean isCompressed) throws IOException {
 
 	InputStream is = new ByteArrayInputStream(dataBytes);

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/SerializeUtil.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/SerializeUtil.java
@@ -69,7 +69,7 @@ public class SerializeUtil
 	OutputStream os = bytesOut;
 	
 	if (compress) {
-		os = new DeflaterOutputStream(os);
+	    os = new DeflaterOutputStream(os);
 	}
 	
 	DataOutputStream dataOut = new DataOutputStream(os);
@@ -126,14 +126,14 @@ public class SerializeUtil
 	DataInputStream dataIn = new DataInputStream(is);
 	ClassLoadingAwareObjectInputStream objIn = new ClassLoadingAwareObjectInputStream(dataIn);
 	try {
-	 	return (Serializable) objIn.readObject();
+	     return (Serializable) objIn.readObject();
 	 	
 	} catch (ClassNotFoundException ce) {
-		throw new IOException(ce.getMessage());
+	     throw new IOException(ce.getMessage());
 		
 	} finally {
-		objIn.close();
-		dataIn.close();
+	     objIn.close();
+    	     dataIn.close();
 	}
 
     }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/SerializeUtil.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/SerializeUtil.java
@@ -50,20 +50,20 @@ public class SerializeUtil
     
     public static byte[] serializeOOS(Serializable serializable, boolean compress) throws IOException {
   
-		ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-		OutputStream os = bytesOut;
-		
-		if (compress) {
-			os = new DeflaterOutputStream(os);
-		}
-		
-		DataOutputStream dataOut = new DataOutputStream(os);
-		ObjectOutputStream objOut = new ObjectOutputStream(dataOut);
-		objOut.writeObject(serializable);
-		objOut.flush();
-		objOut.reset();
-		objOut.close();
-		return bytesOut.toByteArray();
+	ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+	OutputStream os = bytesOut;
+	
+	if (compress) {
+		os = new DeflaterOutputStream(os);
+	}
+	
+	DataOutputStream dataOut = new DataOutputStream(os);
+	ObjectOutputStream objOut = new ObjectOutputStream(dataOut);
+	objOut.writeObject(serializable);
+	objOut.flush();
+	objOut.reset();
+	objOut.close();
+	return bytesOut.toByteArray();
 
     }
 
@@ -93,22 +93,22 @@ public class SerializeUtil
     
     public static Serializable deserializeOOS(byte[] dataBytes, boolean isCompressed) throws IOException {
 
-		InputStream is = new ByteArrayInputStream(dataBytes);
-		if(isCompressed) {
-			is = new InflaterInputStream(is);
-		}
-		DataInputStream dataIn = new DataInputStream(is);
-		ClassLoadingAwareObjectInputStream objIn = new ClassLoadingAwareObjectInputStream(dataIn);
-		try {
-		 	return (Serializable) objIn.readObject();
-		 	
-		} catch (ClassNotFoundException ce) {
-			throw new IOException(ce.getMessage());
-			
-		} finally {
-			objIn.close();
-			dataIn.close();
-		}
+	InputStream is = new ByteArrayInputStream(dataBytes);
+	if(isCompressed) {
+		is = new InflaterInputStream(is);
+	}
+	DataInputStream dataIn = new DataInputStream(is);
+	ClassLoadingAwareObjectInputStream objIn = new ClassLoadingAwareObjectInputStream(dataIn);
+	try {
+	 	return (Serializable) objIn.readObject();
+	 	
+	} catch (ClassNotFoundException ce) {
+		throw new IOException(ce.getMessage());
+		
+	} finally {
+		objIn.close();
+		dataIn.close();
+	}
 
     }
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/SerializeUtil.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/util/SerializeUtil.java
@@ -73,6 +73,13 @@ public class SerializeUtil
         byte [] dataBytes = Base64.decodeBase64(s.getBytes("UTF-8"));
         return deserialize(dataBytes);
     }
+    
+    public static Serializable deserializeFromStringOOS(String s) throws IOException
+    {
+        // Initialize buffer and converter
+        byte [] dataBytes = Base64.decodeBase64(s.getBytes("UTF-8"));
+        return deserializeOOS(dataBytes);
+    }
 
     public static Serializable deserialize(byte[] dataBytes) throws IOException {
         Hessian2Input hessian2Input = new Hessian2Input( new ByteArrayInputStream(  dataBytes ) );


### PR DESCRIPTION
So basically this boiled down to creating some new implementations of serialize/deserialize that use ObjectOutputStream as well as support being called w/ optional compression (which might be useful due to SQS message size limits). 

The unit test still works and I added a new test for the transient referenced flagged TestObject with the special methods as described at http://docs.oracle.com/javase/7/docs/api/java/io/ObjectOutputStream.html to verify that if people want to send object messages w/ transient flagged fields AND they have these methods implemented, things will work as they expect.

Hopefully this fix can be put in, or some options to somehow enable the caller to decide which serialization engine to run that the project owner could discuss/implement? What do you think?
