### PR TITLE
Custom visibility timeout for each message in SQS queue

### DIFF
--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/AbstractSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/AbstractSQSConnector.java
@@ -29,8 +29,7 @@ import java.util.Map;
  */
 public abstract class AbstractSQSConnector implements SQSConnector {
     protected static final String AWS_ERROR_CODE_AUTHENTICATION = "InvalidClientTokenId";
-    protected static final String BLANK_STRING = "";
-
+   
     protected final Log _log = LogFactory.getLog(getClass());
 
     private final long _receiveCheckIntervalMs;
@@ -59,8 +58,8 @@ public abstract class AbstractSQSConnector implements SQSConnector {
     }
     
     public int getVisibilityTimeoutOnReset() {
-		return _visibilityTimeoutOnReset;
-	}
+	return _visibilityTimeoutOnReset;
+    }
 
     public void sendMessage(NevadoDestination destination, NevadoMessage message) throws JMSException
     {
@@ -139,7 +138,7 @@ public abstract class AbstractSQSConnector implements SQSConnector {
                     "Did this come from an SQS queue?");
         }
         SQSQueue sqsQueue = getSQSQueue(message.getNevadoDestination());
-        if (sqsReceiptHandle != null && !BLANK_STRING.equals(sqsReceiptHandle)){
+        if (sqsReceiptHandle != null && StringUtils.isEmpty(sqsReceiptHandle) && sqsReceiptHandle.trim().length() == 0) {
         	sqsQueue.setMessageVisibilityTimeout(sqsReceiptHandle, _visibilityTimeoutOnReset); // Customize message visibility timeout
         }
     }
@@ -193,7 +192,7 @@ public abstract class AbstractSQSConnector implements SQSConnector {
                 if (sqsMessage != null && !connection.isRunning()) {
                     // Connection was stopped while the REST call to SQS was being made
                     try {
-                        if (sqsMessage.getReceiptHandle() != null && !BLANK_STRING.equals(sqsMessage.getReceiptHandle())) {
+                        if (sqsMessage.getReceiptHandle() != null && StringUtils.isEmpty(sqsMessage.getReceiptHandle()) && sqsMessage.getReceiptHandle().trim().length() == 0) {
                     		sqsQueue.setMessageVisibilityTimeout(sqsMessage.getReceiptHandle(), _visibilityTimeoutOnReset); // Customize message visibility timeout
                     	}
                     } catch (JMSException e) {

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/AbstractSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/AbstractSQSConnector.java
@@ -138,7 +138,7 @@ public abstract class AbstractSQSConnector implements SQSConnector {
                     "Did this come from an SQS queue?");
         }
         SQSQueue sqsQueue = getSQSQueue(message.getNevadoDestination());
-        if (sqsReceiptHandle != null && StringUtils.isEmpty(sqsReceiptHandle) && sqsReceiptHandle.trim().length() == 0) {
+        if (sqsReceiptHandle != null && StringUtils.isNotEmpty(sqsReceiptHandle) && sqsReceiptHandle.trim().length() != 0){
         	sqsQueue.setMessageVisibilityTimeout(sqsReceiptHandle, _visibilityTimeoutOnReset); // Customize message visibility timeout
         }
     }
@@ -192,7 +192,7 @@ public abstract class AbstractSQSConnector implements SQSConnector {
                 if (sqsMessage != null && !connection.isRunning()) {
                     // Connection was stopped while the REST call to SQS was being made
                     try {
-                        if (sqsMessage.getReceiptHandle() != null && StringUtils.isEmpty(sqsMessage.getReceiptHandle()) && sqsMessage.getReceiptHandle().trim().length() == 0) {
+                        if (sqsMessage.getReceiptHandle() != null && StringUtils.isNotEmpty(sqsMessage.getReceiptHandle()) && sqsMessage.getReceiptHandle().trim().length() != 0) {
                     		sqsQueue.setMessageVisibilityTimeout(sqsMessage.getReceiptHandle(), _visibilityTimeoutOnReset); // Customize message visibility timeout
                     	}
                     } catch (JMSException e) {

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
@@ -53,10 +53,6 @@ public class AmazonAwsSQSConnector extends AbstractSQSConnector {
     public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs) {
         this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false, 0);
     }
-    
-    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, int visibilityTimeoutOnReset) {
-        this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false, visibilityTimeoutOnReset);
-    }
 
     public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync, int visibilityTimeoutOnReset) {
         super(receiveCheckIntervalMs, isAsync, visibilityTimeoutOnReset);

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
@@ -50,12 +50,12 @@ public class AmazonAwsSQSConnector extends AbstractSQSConnector {
     private final AmazonSQS _amazonSQS;
     private final AmazonSNS _amazonSNS;
 
-    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs) {
-        this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false);
+    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, , int visibilityTimeoutOnReset) {
+        this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false, visibilityTimeoutOnReset);
     }
 
-    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync) {
-        super(receiveCheckIntervalMs, isAsync);
+    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync, int visibilityTimeoutOnReset) {
+        super(receiveCheckIntervalMs, isAsync, visibilityTimeoutOnReset);
         AWSCredentials awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         String proxyHost = System.getProperty("http.proxyHost");

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
@@ -54,6 +54,29 @@ public class AmazonAwsSQSConnector extends AbstractSQSConnector {
         this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false, 0);
     }
 
+    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync) {
+        super(receiveCheckIntervalMs, isAsync);
+        AWSCredentials awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        String proxyHost = System.getProperty("http.proxyHost");
+        String proxyPort = System.getProperty("http.proxyPort");
+        if(proxyHost != null){
+            clientConfiguration.setProxyHost(proxyHost);
+            if(proxyPort != null){
+              clientConfiguration.setProxyPort(Integer.parseInt(proxyPort));
+            }
+        }  
+        clientConfiguration.setProtocol(isSecure ? Protocol.HTTPS : Protocol.HTTP);
+        if (isAsync) {
+            ExecutorService executorService = Executors.newSingleThreadExecutor();
+            _amazonSQS = new AmazonSQSAsyncClient(awsCredentials, clientConfiguration, executorService);
+            _amazonSNS = new AmazonSNSAsyncClient(awsCredentials, clientConfiguration, executorService);
+        } else {
+            _amazonSQS = new AmazonSQSClient(awsCredentials, clientConfiguration);
+            _amazonSNS = new AmazonSNSClient(awsCredentials, clientConfiguration);
+        }
+    }
+    
     public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync, int visibilityTimeoutOnReset) {
         super(receiveCheckIntervalMs, isAsync, visibilityTimeoutOnReset);
         AWSCredentials awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
@@ -50,7 +50,11 @@ public class AmazonAwsSQSConnector extends AbstractSQSConnector {
     private final AmazonSQS _amazonSQS;
     private final AmazonSNS _amazonSNS;
 
-    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, , int visibilityTimeoutOnReset) {
+    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs) {
+        this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false, 0);
+    }
+    
+    public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, int visibilityTimeoutOnReset) {
         this(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, false, visibilityTimeoutOnReset);
     }
 

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
@@ -10,12 +10,12 @@ import org.skyscreamer.nevado.jms.connector.AbstractSQSConnectorFactory;
  */
 public class AmazonAwsSQSConnectorFactory extends AbstractSQSConnectorFactory {
     protected boolean _useAsyncSend = false;
-    protected int visibilityTimeoutOnReset;
+    protected int _visibilityTimeoutOnReset;
     
     @Override
     public AmazonAwsSQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint) {
         AmazonAwsSQSConnector amazonAwsSQSConnector = new AmazonAwsSQSConnector(awsAccessKey, awsSecretKey, _isSecure,
-                _receiveCheckIntervalMs, _useAsyncSend, visibilityTimeoutOnReset);
+                _receiveCheckIntervalMs, _useAsyncSend, _visibilityTimeoutOnReset);
         if (StringUtils.isNotEmpty(awsSQSEndpoint)) {
             amazonAwsSQSConnector.getAmazonSQS().setEndpoint(awsSQSEndpoint);
         }
@@ -33,11 +33,11 @@ public class AmazonAwsSQSConnectorFactory extends AbstractSQSConnectorFactory {
         return _useAsyncSend;
     }
     
-    public int getVisibilityTimeoutOnReset() {
-		return visibilityTimeoutOnReset;
+   public int get_visibilityTimeoutOnReset() {
+		return _visibilityTimeoutOnReset;
 	}
 
-	public void setVisibilityTimeoutOnReset(int visibilityTimeoutOnReset) {
-		this.visibilityTimeoutOnReset = visibilityTimeoutOnReset;
+	public void set_visibilityTimeoutOnReset(int visibilityTimeoutOnReset) {
+		_visibilityTimeoutOnReset = visibilityTimeoutOnReset;
 	}
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
@@ -10,11 +10,12 @@ import org.skyscreamer.nevado.jms.connector.AbstractSQSConnectorFactory;
  */
 public class AmazonAwsSQSConnectorFactory extends AbstractSQSConnectorFactory {
     protected boolean _useAsyncSend = false;
+    protected int visibilityTimeoutOnReset;
     
     @Override
     public AmazonAwsSQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint) {
         AmazonAwsSQSConnector amazonAwsSQSConnector = new AmazonAwsSQSConnector(awsAccessKey, awsSecretKey, _isSecure,
-                _receiveCheckIntervalMs, _useAsyncSend);
+                _receiveCheckIntervalMs, _useAsyncSend, visibilityTimeoutOnReset);
         if (StringUtils.isNotEmpty(awsSQSEndpoint)) {
             amazonAwsSQSConnector.getAmazonSQS().setEndpoint(awsSQSEndpoint);
         }
@@ -31,4 +32,12 @@ public class AmazonAwsSQSConnectorFactory extends AbstractSQSConnectorFactory {
     public boolean isUseAsyncSend() {
         return _useAsyncSend;
     }
+    
+    public int getVisibilityTimeoutOnReset() {
+		return visibilityTimeoutOnReset;
+	}
+
+	public void setVisibilityTimeoutOnReset(int visibilityTimeoutOnReset) {
+		this.visibilityTimeoutOnReset = visibilityTimeoutOnReset;
+	}
 }

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
@@ -33,11 +33,11 @@ public class AmazonAwsSQSConnectorFactory extends AbstractSQSConnectorFactory {
         return _useAsyncSend;
     }
     
-   public int get_visibilityTimeoutOnReset() {
-		return _visibilityTimeoutOnReset;
-	}
+   public int getVisibilityTimeoutOnReset() {
+	return _visibilityTimeoutOnReset;
+    }
 
-	public void set_visibilityTimeoutOnReset(int visibilityTimeoutOnReset) {
-		_visibilityTimeoutOnReset = visibilityTimeoutOnReset;
-	}
+   public void setVisibilityTimeoutOnReset(int visibilityTimeoutOnReset) {
+	_visibilityTimeoutOnReset = visibilityTimeoutOnReset;
+   }
 }


### PR DESCRIPTION
First the visibility timeout for each message was set to 0. Now we can set a custom value from 0 to 43200 seconds.12 hours is the maximum. We just need to set it in spring configuration as a property of AmazonAwsSQSConnectorFactory. name="visibilityTimeoutOnReset" value="10"
