### PR TITLE
AsyncConsumerRunner lazy initialization

### DIFF
--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoMessageConsumer.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoMessageConsumer.java
@@ -67,6 +67,9 @@ public class NevadoMessageConsumer implements MessageConsumer, QueueReceiver, To
     public void setMessageListener(MessageListener messageListener) throws JMSException {
         checkClosed();
         _messageListener = messageListener;
+
+        //lazy start of AsyncConsumerRunner only when at least one MessageListener registered for consumer
+        _session.getAsyncConsumerRunner().start();
     }
 
     @Override

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoSession.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoSession.java
@@ -618,4 +618,8 @@ public class NevadoSession implements Session {
             throw new JMSException("SESSION DELIBERATELY THROWING EXCEPTION - EXPECTED BEHAVIOR - FOR TESTING MODE ONLY");
         }
     }
+
+    AsyncConsumerRunner getAsyncConsumerRunner(){
+      return _asyncConsumerRunner;
+    }
 }


### PR DESCRIPTION
Start AsyncConsumerRunner lazy, when at least one async MessageHandler registered.
https://github.com/skyscreamer/nevado/issues/97
