### PR TITLE
Added support for instance profile credentials

### DIFF
--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA4</version>
+    <version>1.3.2-OA5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA4-SNAPSHOT</version>
+    <version>1.3.2-OA4</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -65,11 +65,19 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.23.1</version> <!-- or latest stable -->
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.23.1</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA5</version>
+    <version>1.3.2-OA6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA3</version>
+    <version>1.3.2-OA4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>
@@ -73,12 +73,22 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.377</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sns</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.377</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.12.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.12.7</version>
         </dependency>
 
         <dependency>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA3-SNAPSHOT</version>
+    <version>1.3.2-OA3</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA2</version>
+    <version>1.3.2-OA3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>
@@ -53,11 +53,11 @@
             <artifactId>json</artifactId>
             <version>20090211</version>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>1.9.12</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.codehaus.jackson</groupId>-->
+<!--            <artifactId>jackson-core-asl</artifactId>-->
+<!--            <version>1.9.12</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
@@ -72,8 +72,13 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.6.12</version>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+            <version>1.12.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+            <version>1.12.1</version>
         </dependency>
 
         <dependency>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA5-SNAPSHOT</version>
+    <version>1.3.2-OA5</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA6-SNAPSHOT</version>
+    <version>1.3.2-OA6</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>nevado</artifactId>
-        <version>1.3.2-OA</version>
+        <version>1.3.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-OA</version>
+    <version>1.3.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.3.2-OA</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>nevado</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.2-OA</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>nevado</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.3.2</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>

--- a/nevado-jms/pom.xml
+++ b/nevado-jms/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>nevado</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.2</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado-jms</artifactId>
-    <version>1.3.3-SNAPSHOT</version>
+    <version>1.3.2-OA2</version>
     <packaging>jar</packaging>
 
     <name>Nevado JMS</name>

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoSession.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoSession.java
@@ -355,8 +355,10 @@ public class NevadoSession implements Session {
         
         if (_connection.getClientID() != null)
         {
-            queueName += "_client-" + _connection.getClientID() + "";
+            queueName += "_" + _connection.getClientID() + "";
         }
+
+        
         return queueName;
     }
 

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
@@ -6,6 +6,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSAsync;
 import com.amazonaws.services.sns.AmazonSNSAsyncClient;
@@ -56,7 +57,12 @@ public class AmazonAwsSQSConnector extends AbstractSQSConnector {
 
     public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync) {
         super(receiveCheckIntervalMs, isAsync);
-        AWSCredentials awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        AWSCredentials awsCredentials;
+        if(awsAccessKey != null && awsSecretKey != null) {
+            awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        } else {
+            awsCredentials = new InstanceProfileCredentialsProvider().getCredentials();
+        }
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         String proxyHost = System.getProperty("http.proxyHost");
         String proxyPort = System.getProperty("http.proxyPort");

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnector.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import com.amazonaws.services.sqs.model.CreateQueueResult;
 import com.amazonaws.services.sqs.model.ListQueuesRequest;
 import com.amazonaws.services.sqs.model.ListQueuesResult;
+import org.apache.commons.lang.StringUtils;
 import org.skyscreamer.nevado.jms.connector.AbstractSQSConnector;
 import org.skyscreamer.nevado.jms.connector.SQSMessage;
 import org.skyscreamer.nevado.jms.connector.SQSQueue;
@@ -61,7 +62,7 @@ public class AmazonAwsSQSConnector extends AbstractSQSConnector {
     public AmazonAwsSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure, long receiveCheckIntervalMs, boolean isAsync) {
         super(receiveCheckIntervalMs, isAsync);
         AWSCredentials awsCredentials;
-        if(awsAccessKey != null && awsSecretKey != null) {
+        if(StringUtils.isNotEmpty(awsAccessKey) && StringUtils.isNotEmpty(awsSecretKey)) {
             awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
         } else {
             awsCredentials = new InstanceProfileCredentialsProvider().getCredentials();

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/AmazonAwsSQSConnectorFactory.java
@@ -15,19 +15,13 @@ public class AmazonAwsSQSConnectorFactory extends AbstractSQSConnectorFactory {
 
     @Override
     public AmazonAwsSQSConnector getInstance(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint) {
-        AmazonAwsSQSConnector amazonAwsSQSConnector = createConnector(awsAccessKey, awsSecretKey);
+        AmazonAwsSQSConnector amazonAwsSQSConnector = createConnector(awsAccessKey, awsSecretKey, awsSQSEndpoint, awsSNSEndpoint);
         amazonAwsSQSConnector.setTestAlwaysPasses(_testAlwaysPasses);
-        if (StringUtils.isNotEmpty(awsSQSEndpoint)) {
-            amazonAwsSQSConnector.getAmazonSQS().setEndpoint(awsSQSEndpoint);
-        }
-        if (StringUtils.isNotEmpty(awsSNSEndpoint)) {
-            amazonAwsSQSConnector.getAmazonSNS().setEndpoint(awsSNSEndpoint);
-        }
         return amazonAwsSQSConnector;
     }
 
-    protected AmazonAwsSQSConnector createConnector(String awsAccessKey, String awsSecretKey) {
-        return new AmazonAwsSQSConnector(awsAccessKey, awsSecretKey, _isSecure, _receiveCheckIntervalMs, _useAsyncSend);
+    protected AmazonAwsSQSConnector createConnector(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint) {
+        return new AmazonAwsSQSConnector(awsAccessKey, awsSecretKey, awsSQSEndpoint, awsSNSEndpoint, _isSecure, _receiveCheckIntervalMs, _useAsyncSend);
     }
 
     public void setUseAsyncSend(boolean useAsyncSend) {

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/PlainTextAmazonSQSConnector.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/PlainTextAmazonSQSConnector.java
@@ -14,14 +14,14 @@ import org.skyscreamer.nevado.jms.message.NevadoTextMessage;
  */
 public class PlainTextAmazonSQSConnector extends AmazonAwsSQSConnector {
 
-	public PlainTextAmazonSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure,
+	public PlainTextAmazonSQSConnector(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint, boolean isSecure,
 			long receiveCheckIntervalMs) {
-		super(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs);
+		super(awsAccessKey, awsSecretKey, awsSQSEndpoint, awsSNSEndpoint, isSecure, receiveCheckIntervalMs);
 	}
 
-	public PlainTextAmazonSQSConnector(String awsAccessKey, String awsSecretKey, boolean isSecure,
+	public PlainTextAmazonSQSConnector(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint, boolean isSecure,
 			long receiveCheckIntervalMs, boolean isAsync) {
-		super(awsAccessKey, awsSecretKey, isSecure, receiveCheckIntervalMs, isAsync);
+		super(awsAccessKey, awsSecretKey, awsSQSEndpoint, awsSNSEndpoint, isSecure, receiveCheckIntervalMs, isAsync);
 	}
 
 	@Override

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/PlainTextAmazonSQSConnectorFactory.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/connector/amazonaws/PlainTextAmazonSQSConnectorFactory.java
@@ -11,8 +11,8 @@ import org.skyscreamer.nevado.jms.connector.amazonaws.AmazonAwsSQSConnectorFacto
 public class PlainTextAmazonSQSConnectorFactory extends AmazonAwsSQSConnectorFactory {
 
     @Override
-    protected AmazonAwsSQSConnector createConnector(String awsAccessKey, String awsSecretKey) {
-        return new PlainTextAmazonSQSConnector(awsAccessKey, awsSecretKey, _isSecure, _receiveCheckIntervalMs,
+    protected AmazonAwsSQSConnector createConnector(String awsAccessKey, String awsSecretKey, String awsSQSEndpoint, String awsSNSEndpoint) {
+        return new PlainTextAmazonSQSConnector(awsAccessKey, awsSecretKey, awsSQSEndpoint, awsSNSEndpoint, _isSecure, _receiveCheckIntervalMs,
                 _useAsyncSend);
     }
 

--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/destination/NevadoProviderQueuePrefix.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/destination/NevadoProviderQueuePrefix.java
@@ -6,7 +6,7 @@ package org.skyscreamer.nevado.jms.destination;
  * @author Carter Page <carter@skyscreamer.org>
  */
 public enum NevadoProviderQueuePrefix {
-    TEMPORARY_DESTINATION_PREFIX("nevado_temp_"), DURABLE_SUBSCRIPTION_PREFIX("nevado_durable_topic_");
+    TEMPORARY_DESTINATION_PREFIX("nevado_temp_"), DURABLE_SUBSCRIPTION_PREFIX("nev_");
 
     private final String _value;
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.2-OA5-SNAPSHOT</version>
+    <version>1.3.2-OA5</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.3-SNAPSHOT</version>
+    <version>1.3.2-OA3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.2-OA6-SNAPSHOT</version>
+    <version>1.3.2-OA6</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.2-OA3-SNAPSHOT</version>
+    <version>1.3.2-OA3</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.2-OA4-SNAPSHOT</version>
+    <version>1.3.2-OA4</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.2-OA5</version>
+    <version>1.3.2-OA6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.2-OA3</version>
+    <version>1.3.2-OA4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.2-OA4</version>
+    <version>1.3.2-OA5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.3-SNAPSHOT</version>
+    <version>1.3.2-OA</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>nevado</artifactId>
-    <version>1.3.2-OA</version>
+    <version>1.3.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Nevado</name>


### PR DESCRIPTION
I've made a small change to the SQS connector class to allow the use of instance profile credentials when no access keys are specified.
This improves security when an EC2 instance has a role that allows it to access the SQS and SNS services since access keys don't need to be stored anywhere.
