### PR TITLE
adding closed sessions cleanup upon new  session creation.

### DIFF
--- a/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnection.java
+++ b/nevado-jms/src/main/java/org/skyscreamer/nevado/jms/NevadoConnection.java
@@ -52,6 +52,7 @@ public class NevadoConnection implements Connection {
         _inUse = true;
         NevadoSession nevadoSession = new NevadoSession(this, transacted, acknowledgeMode);
         initializeSession(nevadoSession);
+        cleanUpClosedSessions();
         return nevadoSession;
     }
 
@@ -65,6 +66,18 @@ public class NevadoConnection implements Connection {
             {
                 nevadoSession.start();
             }
+        }
+    }
+
+    private void cleanUpClosedSessions() {
+        List<NevadoSession> closedSessions = new ArrayList<NevadoSession>();
+        for (NevadoSession session : _sessions) {
+            if(session.isClosed()) {
+                closedSessions.add(session);
+            }
+        }
+        if(!closedSessions.isEmpty()) {
+            _sessions.removeAll(closedSessions);
         }
     }
 


### PR DESCRIPTION
Long story short, I'm using a Spring Integration with a SingleConnectionFactory wrapping NevadoConnectionFactory. 
The key is the word "Single": I endup with one connection for all (3) my jms inbound channels, and it (the connection) keeps adding sessions to NevadoConnection's _sessions, which steadily growth - i get about 1.6 million sessions within 5 days, making my app eventually crash with OOME.
